### PR TITLE
DBスキーマをridgepoleで管理

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'coffee-rails', '4.2.2'
 gem 'jquery-rails', '4.3.1'
 gem 'turbolinks',   '5.0.1'
 gem 'jbuilder',     '2.6.4'
+gem 'ridgepole'
 
 group :development, :test do
     gem 'sqlite3', '1.3.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    diffy (3.2.0)
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.18)
@@ -112,6 +113,9 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    ridgepole (0.7.0)
+      activerecord (>= 5.0.1, < 6)
+      diffy
     sass (3.5.1)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -167,6 +171,7 @@ DEPENDENCIES
   pg (= 0.20.0)
   puma (= 3.9.1)
   rails (= 5.0.3)
+  ridgepole
   sass-rails (= 5.0.6)
   spring (= 2.0.2)
   spring-watcher-listen (= 2.0.1)
@@ -176,4 +181,4 @@ DEPENDENCIES
   web-console (= 3.5.1)
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.16.0.pre.3

--- a/db/Schemafile
+++ b/db/Schemafile
@@ -1,0 +1,7 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+create_table "posts", force: :cascade do |t|
+  t.text     "content"
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+end

--- a/lib/tasks/ridgepole.rake
+++ b/lib/tasks/ridgepole.rake
@@ -1,0 +1,27 @@
+namespace :ridgepole do
+  desc 'Apply database schema'
+  task apply: :environment do
+    ridgepole('--apply', "--file #{schema_file}")
+    Rake::Task['db:schema:dump'].invoke
+  end
+
+  desc 'Export database schema'
+  task export: :environment do
+    ridgepole('--export', "--output #{schema_file}")
+  end
+
+  private
+
+  def schema_file
+    Rails.root.join('db', 'Schemafile')
+  end
+
+  def config_file
+    Rails.root.join('config/database.yml')
+  end
+
+  def ridgepole(*options)
+    command = ['bundle exec ridgepole', "--config #{config_file}", "--env #{Rails.env}"]
+    system [command + options].join(' ')
+  end
+end


### PR DESCRIPTION
@yucayann5 

DBスキーマを全て `db/Schemafile` ファイルで管理するようにします。

- `bundle exec rake ridgepole:apply` でファイルの中身をDBに適用
- `bundle exec rake ridgepole:export` でDBの中身をファイルに吐き出す

（以降、 `db/schema.rb` や `db/migrate` の存在は忘れてください。）